### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,8 @@ gtkguitune (0.8-6) UNRELEASED; urgency=medium
   * Bump debhelper from deprecated 7 to 10.
   * Use secure URI in Vcs control header Vcs-Git.
   * Rely on pre-initialized dpkg-architecture variables.
+  * Remove constraints unnecessary since buster:
+    + Build-Depends: Drop versioned constraint on debhelper.
 
  -- Debian Janitor <janitor@jelmer.uk>  Fri, 24 Apr 2020 08:04:01 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: gtkguitune
 Section: x11
 Priority: optional
 Maintainer: Antonin Kral <A.Kral@sh.cvut.cz>
-Build-Depends: debhelper (>= 10~), libgtkmm-2.4-dev, libgtk2.0-dev, autotools-dev, quilt
+Build-Depends: debhelper, libgtkmm-2.4-dev, libgtk2.0-dev, autotools-dev, quilt
 Standards-Version: 3.9.2
 Vcs-Git: https://github.com/bobek/gtkguitune.git
 Vcs-Browser: https://github.com/bobek/gtkguitune


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/gtkguitune/075a545a-9342-413a-ab22-94b21f17b8fa.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/63/f98582da0f798d1881cff070ae33b78ff13d02.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/7f/1b821c19952dda2c75801a446d7bdd2c060c26.debug
### Control files of package gtkguitune: lines which differ (wdiff format)
* Depends: libatkmm-1.6-1v5 (>= [-2.24.0),-] {+2.28.2),+} libc6 (>= 2.29), libgcc-s1 (>= 3.0), libglib2.0-0 (>= 2.12.0), libglibmm-2.4-1v5 (>= 2.64.2), libgtk2.0-0 (>= 2.8.0), libgtkmm-2.4-1v5 (>= 1:2.24.0), libpangomm-1.4-1v5 (>= [-2.42.0),-] {+2.46.1),+} libsigc++-2.0-0v5 (>= 2.2.0), libstdc++6 (>= 5), oss-compat
### Control files of package gtkguitune-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-7f1b821c19952dda2c75801a446d7bdd2c060c26-] {+63f98582da0f798d1881cff070ae33b78ff13d02+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/075a545a-9342-413a-ab22-94b21f17b8fa/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/075a545a-9342-413a-ab22-94b21f17b8fa/diffoscope)).
